### PR TITLE
Uses Invoke-Build to implement the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,8 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 .idea/
+
+# local build outputs
+_packages/
+_codeCoverage/
+coverage.cobertura.xml

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,15 @@
+# Building vellum-cli
+
+This project uses the [`InvokeBuild`](https://github.com/nightroman/Invoke-Build) PowerShell module for build automation.
+
+It can be installed via the [PowerShell Gallery](https://www.powershellgallery.com/packages/InvokeBuild/), for example:
+
+```
+Install-Module InvokeBuild -Scope CurrentUser -Force -Repository PSGallery
+```
+
+From the root of this repo, run the build as follows:
+
+```
+Invoke-Build ./vellum-cli.build.ps1 -Task .
+```

--- a/Endjin.RecommendedPractices.Build/Endjin.RecommendedPractices.Build.psd1
+++ b/Endjin.RecommendedPractices.Build/Endjin.RecommendedPractices.Build.psd1
@@ -1,0 +1,124 @@
+@{
+
+# Script module or binary module file associated with this manifest.
+RootModule = 'Endjin.RecommendedPractices.Build.psm1'
+
+# Version number of this module.
+ModuleVersion = '0.0.1'
+
+# Supported PSEditions
+# CompatiblePSEditions = @()
+
+# ID used to uniquely identify this module
+GUID = 'a198ab01-a7d8-498c-a497-fc9da76f24f2'
+
+# Author of this module
+Author = 'James Dawson'
+
+# Company or vendor of this module
+CompanyName = 'endjin'
+
+# Copyright statement for this module
+Copyright = '(c) endjin. All rights reserved.'
+
+# Description of the functionality provided by this module
+# Description = ''
+
+# Minimum version of the PowerShell engine required by this module
+# PowerShellVersion = ''
+
+# Name of the PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+# ClrVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+# FunctionsToExport = @()
+
+# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+CmdletsToExport = @()
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+# AliasesToExport = @()
+
+# DSC resources to export from this module
+# DscResourcesToExport = @()
+
+# List of all modules packaged with this module
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+PrivateData = @{
+
+    PSData = @{
+
+        # Tags applied to this module. These help with module discovery in online galleries.
+        # Tags = @()
+
+        # A URL to the license for this module.
+        # LicenseUri = ''
+
+        # A URL to the main website for this project.
+        # ProjectUri = ''
+
+        # A URL to an icon representing this module.
+        # IconUri = ''
+
+        # ReleaseNotes of this module
+        # ReleaseNotes = ''
+
+        # Prerelease string of this module
+        # Prerelease = ''
+
+        # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+        # RequireLicenseAcceptance = $false
+
+        # External dependent modules of this module
+        # ExternalModuleDependencies = @()
+
+    } # End of PSData hashtable
+
+} # End of PrivateData hashtable
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}
+

--- a/Endjin.RecommendedPractices.Build/Endjin.RecommendedPractices.Build.psm1
+++ b/Endjin.RecommendedPractices.Build/Endjin.RecommendedPractices.Build.psm1
@@ -1,0 +1,24 @@
+function Assert-DotNetTool
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string] $Name,
+
+        [Parameter()]
+        [Version] $Version,
+        
+        [Parameter()]
+        [bool] $Global = $true
+    )
+
+    $existingTools = & dotnet tool list -g
+    
+    if ( !($existingTools | select-string $Name) ) {
+        & dotnet tool install -g $Name --version "$Version"
+    }
+}
+
+Set-Alias Endjin.RecommendedPractices.Build.tasks $PSScriptRoot/Endjin.RecommendedPractices.Build.tasks.ps1
+Export-ModuleMember -Function Assert-DotNetTool `
+                    -Alias Endjin.RecommendedPractices.Build.tasks

--- a/Endjin.RecommendedPractices.Build/Endjin.RecommendedPractices.Build.tasks.ps1
+++ b/Endjin.RecommendedPractices.Build/Endjin.RecommendedPractices.Build.tasks.ps1
@@ -3,7 +3,17 @@ task GitVersion {
     $gitVersionOutputJson = exec { dotnet-gitversion /output json /nofetch }
     $env:GitVersionOutput = $gitVersionOutputJson
     $script:GitVersion = $gitVersionOutputJson | ConvertFrom-Json -AsHashtable
-    
+
+    # Set the native GitVersion output as environment variables
+    foreach ($var in $script:GitVersion.Keys) {
+        Set-Item -Path "env:GITVERSION_$var" -Value $script:GitVersion[$var]
+    }
+
+    # Starting with GitVersion 5.2.0, GitVersion includes isOutput=true on all of the variables it
+    # sets, which is a breaking change. It means that these variables are no longer available with
+    # the same name - they must now be qualified by the name of the task that produced them.
+    # You can't turn this off, so we have to adapt to it. This just republishes them by their
+    # old names, meaning anything previously depending on those names will continue to work.
     Write-Build Green "##vso[task.setvariable variable=GitVersion.SemVer]$($script:GitVersion.SemVer)"
     Write-Build Green "##vso[task.setvariable variable=GitVersion.PreReleaseTag]$($script:GitVersion.PreReleaseTag)"
     Write-Build Green "##vso[task.setvariable variable=GitVersion.MajorMinorPatch]$($script:GitVersion.MajorMinorPatch)"

--- a/Endjin.RecommendedPractices.Build/Endjin.RecommendedPractices.Build.tasks.ps1
+++ b/Endjin.RecommendedPractices.Build/Endjin.RecommendedPractices.Build.tasks.ps1
@@ -1,0 +1,56 @@
+task GitVersion {
+    Assert-DotNetTool -Name "GitVersion.Tool" -Version 5.2.0
+    $gitVersionOutputJson = exec { dotnet-gitversion /output json /nofetch }
+    $env:GitVersionOutput = $gitVersionOutputJson
+    $script:GitVersion = $gitVersionOutputJson | ConvertFrom-Json -AsHashtable
+    
+    Write-Build Green "##vso[task.setvariable variable=GitVersion.SemVer]$($script:GitVersion.SemVer)"
+    Write-Build Green "##vso[task.setvariable variable=GitVersion.PreReleaseTag]$($script:GitVersion.PreReleaseTag)"
+    Write-Build Green "##vso[task.setvariable variable=GitVersion.MajorMinorPatch]$($script:GitVersion.MajorMinorPatch)"
+}
+
+task Build {
+    exec { 
+        dotnet build $SolutionToBuild `
+                     --configuration $Configuration `
+                     /p:Version="$(($script:GitVersion).SemVer)" `
+                     /p:EndjinRepositoryUrl="$BuildRepositoryUri" `
+                     --verbosity $LogLevel
+    }
+}
+
+task Test {
+    exec { 
+        dotnet test $SolutionToBuild `
+                    --configuration $Configuration `
+                    --no-build `
+                    --no-restore `
+                    /p:CollectCoverage=true `
+                    /p:CoverletOutputFormat=cobertura `
+                    --verbosity $LogLevel
+    }
+}
+
+task TestReport {
+    Assert-DotNetTool -Name "dotnet-reportgenerator-globaltool" -Version 4.8.3
+    exec {
+        reportgenerator "-reports:$SourcesDir/**/**/coverage.cobertura.xml" `
+                        "-targetdir:$CoverageDir" `
+                        "-reporttypes:$TestReportTypes"
+    }
+}
+
+task Package {
+    exec { 
+        dotnet pack $SolutionToBuild `
+                    --configuration $Configuration `
+                    --no-build `
+                    --no-restore `
+                    --output $PackagesDir `
+                    /p:EndjinRepositoryUrl="BuildRepositoryUri" `
+                    /p:PackageVersion="$(($script:GitVersion).SemVer)" `
+                    --verbosity $LogLevel
+    }
+}
+
+task FullBuild GitVersion,Build,Test,TestReport,Package

--- a/Solutions/Vellum.Cli.Cloudinary/NuGetDefense.json
+++ b/Solutions/Vellum.Cli.Cloudinary/NuGetDefense.json
@@ -1,0 +1,32 @@
+{
+  "WarnOnly": false,
+  "VulnerabilityReports": {
+    "OutputTextReport": true
+  },
+  "CheckTransitiveDependencies": true,
+  "ErrorSettings": {
+    "ErrorSeverityThreshold": "any",
+    "Cvss3Threshold": -1,
+    "IgnoredPackages": [
+      {
+        "Id": "NugetDefense"
+      }
+    ],
+    "IgnoredCvEs": [],
+    "AllowedPackages": [],
+    "BlockedPackages": []
+  },
+  "OssIndex": {
+    "ApiToken": "",
+    "Username": "",
+    "Enabled": true,
+    "BreakIfCannotRun": true
+  },
+  "NVD": {
+    "SelfUpdate": false,
+    "TimeoutInSeconds": 15,
+    "Enabled": true,
+    "BreakIfCannotRun": true
+  },
+  "SensitivePackages": []
+}

--- a/Solutions/Vellum.Cli.Cloudinary/Vellum.Cli.Cloudinary.csproj
+++ b/Solutions/Vellum.Cli.Cloudinary/Vellum.Cli.Cloudinary.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NuspecFile>Vellum.Cli.Cloudinary.nuspec</NuspecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Solutions/Vellum.Cli.Cloudinary/Vellum.Cli.Cloudinary.csproj
+++ b/Solutions/Vellum.Cli.Cloudinary/Vellum.Cli.Cloudinary.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NuGetDefense" Version="1.0.15.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
   </ItemGroup>
 

--- a/Solutions/Vellum.Cli.Tinify/NuGetDefense.json
+++ b/Solutions/Vellum.Cli.Tinify/NuGetDefense.json
@@ -1,0 +1,32 @@
+{
+  "WarnOnly": false,
+  "VulnerabilityReports": {
+    "OutputTextReport": true
+  },
+  "CheckTransitiveDependencies": true,
+  "ErrorSettings": {
+    "ErrorSeverityThreshold": "any",
+    "Cvss3Threshold": -1,
+    "IgnoredPackages": [
+      {
+        "Id": "NugetDefense"
+      }
+    ],
+    "IgnoredCvEs": [],
+    "AllowedPackages": [],
+    "BlockedPackages": []
+  },
+  "OssIndex": {
+    "ApiToken": "",
+    "Username": "",
+    "Enabled": true,
+    "BreakIfCannotRun": true
+  },
+  "NVD": {
+    "SelfUpdate": false,
+    "TimeoutInSeconds": 15,
+    "Enabled": true,
+    "BreakIfCannotRun": true
+  },
+  "SensitivePackages": []
+}

--- a/Solutions/Vellum.Cli.Tinify/Vellum.Cli.Tinify.csproj
+++ b/Solutions/Vellum.Cli.Tinify/Vellum.Cli.Tinify.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NuspecFile>Vellum.Cli.Tinify.nuspec</NuspecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Solutions/Vellum.Cli.Tinify/Vellum.Cli.Tinify.csproj
+++ b/Solutions/Vellum.Cli.Tinify/Vellum.Cli.Tinify.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NuGetDefense" Version="1.0.15.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
   </ItemGroup>
 

--- a/Solutions/Vellum.Cli/NuGetDefense.json
+++ b/Solutions/Vellum.Cli/NuGetDefense.json
@@ -1,0 +1,26 @@
+{
+  "WarnOnly": false,
+  "ErrorSettings": {
+    "ErrorSeverityThreshold": 5,
+    "CVSS3Threshold": -1,
+    "IgnoredPackages": [
+      {
+        "Id": "NugetDefense",
+        "Version": "1.0.6"
+      }
+    ],
+    "IgnoredCvEs": [],
+    "WhiteListedPackages": [],
+    "BlackListedPackages": []
+  },
+  "OssIndex": {
+    "Enabled": true,
+    "BreakIfCannotRun": true
+  },
+  "NVD": {
+    "SelfUpdate": false,
+    "TimeoutInSeconds": 15,
+    "Enabled": true,
+    "BreakIfCannotRun": true
+  }
+}

--- a/Solutions/Vellum.Cli/Vellum.Cli.csproj
+++ b/Solutions/Vellum.Cli/Vellum.Cli.csproj
@@ -45,6 +45,7 @@
     </PackageReference>
     <PackageReference Include="Markdig" Version="0.22.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
+    <PackageReference Include="NuGetDefense" Version="1.0.15.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="1.3.1" />
     <PackageReference Include="NDepend.Path" Version="2.0.0" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ resources:
       ref: refs/heads/feature/invokebuild-spike
 
 jobs:
-- template: templates/build.and.release.yml@recommended_practices
+- template: templates/build.and.release.invokebuild.yml@recommended_practices
   parameters:
     vmImage: 'ubuntu-latest'
     service_connection_nuget_org: $(Endjin_Service_Connection_NuGet_Org)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,10 +23,3 @@ jobs:
     service_connection_github: $(Endjin_Service_Connection_GitHub)
     build_script: ./vellum-cli.build.ps1
     netSdkVersion: '3.x'
-    prePublishReleaseArtifacts:
-      - task: CopyFiles@2
-        displayName: 'Copy .nuspec Generated NuGet Packages To Release Folder'
-        inputs:
-          SourceFolder: '$(Build.ArtifactStagingDirectory)'
-          Contents: '*.nupkg'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)/Release/NuGet/Packages/$(Build.BuildID)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ resources:
       type: github
       name: endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub
       endpoint: vellum-dotnet-github
-      ref: refs/heads/invokebuild-spike
+      ref: refs/heads/feature/invokebuild-spike
 
 jobs:
 - template: templates/build.and.release.yml@recommended_practices

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ resources:
       type: github
       name: endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub
       endpoint: vellum-dotnet-github
-      ref: refs/tags/last-known-good
+      ref: refs/heads/invokebuild-spike
 
 jobs:
 - template: templates/build.and.release.yml@recommended_practices
@@ -21,26 +21,9 @@ jobs:
     vmImage: 'ubuntu-latest'
     service_connection_nuget_org: $(Endjin_Service_Connection_NuGet_Org)
     service_connection_github: $(Endjin_Service_Connection_GitHub)
-    solution_to_build: $(Endjin_Solution_To_Build)
+    build_script: ./vellum-cli.build.ps1
     netSdkVersion: '3.x'
     prePublishReleaseArtifacts:
-      - task: DotNetCoreCLI@2
-        displayName: 'Publish Assets for .nuspec Packages'
-        inputs:
-          command: 'publish'
-          zipAfterPublish: False
-          projects: '**/*/*.csproj'
-          arguments: '--configuration $(BuildConfiguration) /p:Version=$(GitVersion.SemVer) --no-build --no-restore'
-          publishWebProjects: False
-          versioningScheme: byBuildNumber
-          buildProperties: 'EndjinRepositoryUrl="$(Build.Repository.Uri)"'
-      - task: NuGetCommand@2
-        displayName: 'Create .nuspec based NuGet Packages'
-        inputs:
-          command: 'pack'
-          packagesToPack: '**/*/*.nuspec'
-          versioningScheme: 'byEnvVar'
-          versionEnvVar: 'GitVersion.SemVer'
       - task: CopyFiles@2
         displayName: 'Copy .nuspec Generated NuGet Packages To Release Folder'
         inputs:

--- a/vellum-cli.build.ps1
+++ b/vellum-cli.build.ps1
@@ -1,0 +1,67 @@
+param (
+    $Configuration = "Release",
+    $BuildRepositoryUri = "",
+    $SourcesDir = $PWD,
+    $CoverageDir = "_codeCoverage",
+    $TestReportTypes = "Cobertura",
+    $PackagesDir = "_packages",
+    $LogLevel = "minimal"
+)
+Get-Module Endjin.RecommendedPractices.Build | Remove-Module -Force
+Import-Module ./Endjin.RecommendedPractices.Build -Verbose
+. Endjin.RecommendedPractices.Build.tasks
+
+# build variables
+$SolutionToBuild = "Solutions/Vellum.Cli.sln"
+$PluginsToPackage = @(
+    "Solutions/Vellum.Cli.Cloudinary/Vellum.Cli.Cloudinary.csproj"
+    "Solutions/Vellum.Cli.Tinify/Vellum.Cli.Tinify.csproj"
+)
+
+# Synopsis: Build, Test and Package
+task . FullBuild
+
+# extensibility targets
+task PreBuild -Before Build
+task PostBuild -After Build
+task PreTest -Before Test
+task PostTest -After Test
+task PreTestReport -Before TestReport
+task PostTestReport -After TestReport
+task PrePackage -Before Package
+task PostPackage -After Package {
+    # custom nuget packaging for plugins
+    $semVer = 
+    Write-Build Green "SemVer: $semver"
+    foreach ($project in $PluginsToPackage) {
+        exec {
+            dotnet publish $project `
+                           --configuration $Configuration `
+                           --no-build `
+                           --no-restore `
+                           /p:Version="$(($script:GitVersion).SemVer)" `
+                           /p:EndjinRepositoryUrl="$BuildRepositoryUri" `
+                           --verbosity $LogLevel
+        }
+
+        # patch the version number in the .nuspec file
+        $nuspecFile = $project -replace "\.csproj",".nuspec"
+        Write-Build Gray "Patching version number in: $nuspecFile"
+        $nuspec = [xml](Get-Content $nuspecFile)
+        $nuspec.package.metadata.version = $script:GitVersion.SemVer
+        $nuspec.Save($nuspecFile)
+
+        exec {
+            dotnet pack $project `
+                        --configuration $Configuration `
+                        --no-build `
+                        --no-restore `
+                        --output $PackagesDir `
+                        /p:EndjinRepositoryUrl="$BuildRepositoryUri" `
+                        /p:IsPackable=true `
+                        /p:IncludeSymbols=false `
+                        /p:NoWarn=NU5100 `
+                        --verbosity $LogLevel
+        }
+    }
+}

--- a/vellum-cli.build.ps1
+++ b/vellum-cli.build.ps1
@@ -46,10 +46,11 @@ task PostPackage -After Package {
 
         # patch the version number in the .nuspec file
         $nuspecFile = $project -replace "\.csproj",".nuspec"
-        Write-Build Gray "Patching version number in: $nuspecFile"
-        $nuspec = [xml](Get-Content $nuspecFile)
+        $nuspecPath = Join-Path -Resolve $PWD $nuspecFile
+        Write-Build Gray "Patching version number in: $nuspecPath"
+        $nuspec = [xml](Get-Content $nuspecPath)
         $nuspec.package.metadata.version = $script:GitVersion.SemVer
-        $nuspec.Save($nuspecFile)
+        $nuspec.Save($nuspecPath)
 
         exec {
             dotnet pack $project `


### PR DESCRIPTION
Resolves the on-going build issue this repo has with previous fixes made the YAML pipeline template that have proved difficult to replicate locally, whilst also suggesting an approach for setting-up build processes that are less tied to specific CI/CD platforms.

Uses the [`Invoke-Build`](https://github.com/nightroman/Invoke-Build) PowerShell module to implement much of what was previously being performed in the `build.and.release` Azure DevOps YAML template.  This allows us to test the build process locally more effectively as we can execute the same script that the build server will.

This initial PR incorporates a new shared PowerShell module (`Endjin.RecommendedPractices.Build` - working title!) that implements the parts of the build process we would want to share across projects, in the same way that the YAML templates allow us.  This is to aid the review process at this stage, however, if we are happy with the approach then it will be moved to a separate repo.

Also includes the following changes:
* Tweaks to the packaging process used for the plugins that use `.nuspec` files to enable them to be built with `dotnet pack`
* Added `NuGetDefense` to check for vulnerable packages

