### PR TITLE
Add unifying adapter between console abstractions

### DIFF
--- a/Solutions/Vellum.Cli/Vellum/Cli/CommandLineParser.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/CommandLineParser.cs
@@ -27,34 +27,36 @@ namespace Vellum.Cli
 
     public class CommandLineParser
     {
+        private readonly IVellumConsole console;
         private readonly IAppEnvironment appEnvironment;
         private readonly ICommandPluginHost commandPluginHost;
         private readonly IServiceCollection services;
 
-        public CommandLineParser(IAppEnvironment appEnvironment, ICommandPluginHost commandPluginHost, IServiceCollection services)
+        public CommandLineParser(IVellumConsole console, IAppEnvironment appEnvironment, ICommandPluginHost commandPluginHost, IServiceCollection services)
         {
+            this.console = console;
             this.services = services;
             this.commandPluginHost = commandPluginHost;
             this.appEnvironment = appEnvironment;
         }
 
-        public delegate Task ContentList(IServiceCollection services, ListOptions options, IConsole console, IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task ContentList(IServiceCollection services, ListOptions options, IVellumConsole console, IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
-        public delegate Task EnvironmentInit(EnvironmentOptions options, IConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task EnvironmentInit(EnvironmentOptions options, IVellumConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
-        public delegate Task NewFile(NewFileOptions fileOptions, IConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task NewFile(NewFileOptions fileOptions, IVellumConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
-        public delegate Task PluginInstall(PluginOptions options, IConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task PluginInstall(PluginOptions options, IVellumConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
-        public delegate Task PluginUninstall(PluginOptions options, IConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task PluginUninstall(PluginOptions options, IVellumConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
-        public delegate Task PluginList(IConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task PluginList(IVellumConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
-        public delegate Task SetEnvironmentSetting(SetOptions options, IConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task SetEnvironmentSetting(SetOptions options, IVellumConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
-        public delegate Task TemplateInstall(TemplateOptions options, IConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task TemplateInstall(TemplateOptions options, IVellumConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
-        public delegate Task TemplateUninstall(TemplateOptions options, IConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
+        public delegate Task TemplateUninstall(TemplateOptions options, IVellumConsole console,  IAppEnvironment appEnvironment, InvocationContext invocationContext = null);
 
         public Parser Create(
             ContentList contentList = null,
@@ -134,7 +136,7 @@ namespace Vellum.Cli
                 {
                     Handler = CommandHandler.Create<ListOptions, InvocationContext>(async (options, context) =>
                     {
-                        await contentList(this.services, options, context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                        await contentList(this.services, options, this.console, this.appEnvironment, context).ConfigureAwait(false);
                     }),
                 };
 
@@ -163,7 +165,7 @@ namespace Vellum.Cli
                 {
                     Handler = CommandHandler.Create<EnvironmentOptions, InvocationContext>(async (options, context) =>
                     {
-                        await environmentInit(options, context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                        await environmentInit(options, this.console, this.appEnvironment, context).ConfigureAwait(false);
                     }),
                 };
 
@@ -238,7 +240,7 @@ namespace Vellum.Cli
 
                 setCmd.Handler = CommandHandler.Create<SetOptions, InvocationContext>(async (options, context) =>
                 {
-                    await setEnvironmentSetting(options, context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                    await setEnvironmentSetting(options, this.console, this.appEnvironment, context).ConfigureAwait(false);
                 });
 
                 cmd.AddCommand(initCmd);
@@ -267,7 +269,7 @@ namespace Vellum.Cli
 
                 cmd.Handler = CommandHandler.Create<NewFileOptions, InvocationContext>(async (options, context) =>
                 {
-                    await newFile(options, context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                    await newFile(options, this.console, this.appEnvironment, context).ConfigureAwait(false);
                 });
 
                 return cmd;
@@ -291,7 +293,7 @@ namespace Vellum.Cli
 
                 installCmd.Handler = CommandHandler.Create<PluginOptions, InvocationContext>(async (options, context) =>
                 {
-                    await pluginInstall(options, context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                    await pluginInstall(options, this.console, this.appEnvironment, context).ConfigureAwait(false);
                 });
 
                 var uninstallCmd = new Command("uninstall", "Uninstall a vellum-cli plugin.")
@@ -306,7 +308,7 @@ namespace Vellum.Cli
 
                 uninstallCmd.Handler = CommandHandler.Create<PluginOptions, InvocationContext>(async (options, context) =>
                 {
-                    await pluginUninstall(options, context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                    await pluginUninstall(options, this.console, this.appEnvironment, context).ConfigureAwait(false);
                 });
 
                 var listCmd = new Command("list", "List vellum-cli plugins.")
@@ -317,7 +319,7 @@ namespace Vellum.Cli
                 {
                     Handler = CommandHandler.Create<InvocationContext>(async (context) =>
                     {
-                        await pluginListInstalled(context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                        await pluginListInstalled(this.console, this.appEnvironment, context).ConfigureAwait(false);
                     }),
                 };
 
@@ -348,7 +350,7 @@ namespace Vellum.Cli
 
                 installCmd.Handler = CommandHandler.Create<TemplateOptions, InvocationContext>(async (options, context) =>
                 {
-                    await templateInstall(options, context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                    await templateInstall(options, this.console, this.appEnvironment, context).ConfigureAwait(false);
                 });
 
                 var uninstallCmd = new Command("uninstall", "Uninstall a vellum-cli template package.")
@@ -363,7 +365,7 @@ namespace Vellum.Cli
 
                 uninstallCmd.Handler = CommandHandler.Create<TemplateOptions, InvocationContext>(async (options, context) =>
                 {
-                    await templateUninstall(options, context.Console, this.appEnvironment, context).ConfigureAwait(false);
+                    await templateUninstall(options, this.console, this.appEnvironment, context).ConfigureAwait(false);
                 });
 
                 packagesCmd.AddCommand(installCmd);

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/Content/ContentListHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/Content/ContentListHandler.cs
@@ -26,7 +26,7 @@ namespace Vellum.Cli.Commands.Content
         public static async Task<int> ExecuteAsync(
             IServiceCollection services,
             ListOptions options,
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/Environment/EnvironmentInitHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/Environment/EnvironmentInitHandler.cs
@@ -14,7 +14,7 @@ namespace Vellum.Cli.Commands.Environment
     {
         public static async Task<int> ExecuteAsync(
             EnvironmentOptions options,
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/Environment/SetEnvironmentSettingHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/Environment/SetEnvironmentSettingHandler.cs
@@ -14,7 +14,7 @@ namespace Vellum.Cli.Commands.Environment
     {
         public static Task<int> ExecuteAsync(
             SetOptions options,
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/New/NewFileHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/New/NewFileHandler.cs
@@ -21,7 +21,7 @@ namespace Vellum.Cli.Commands.New
     {
         public static async Task<int> ExecuteAsync(
             NewFileOptions fileOptions,
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/Plugins/PluginInstallHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/Plugins/PluginInstallHandler.cs
@@ -17,7 +17,7 @@ namespace Vellum.Cli.Commands.Plugins
     {
         public static async Task<int> ExecuteAsync(
             PluginOptions options,
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/Plugins/PluginListInstalledHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/Plugins/PluginListInstalledHandler.cs
@@ -4,7 +4,6 @@
 
 namespace Vellum.Cli.Commands.Plugins
 {
-    using System.CommandLine;
     using System.CommandLine.Invocation;
     using System.Threading.Tasks;
 
@@ -18,13 +17,13 @@ namespace Vellum.Cli.Commands.Plugins
     public static class PluginListInstalledHandler
     {
         public static Task<int> ExecuteAsync(
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {
             var packageManager = new NuGetPluginPackageManager(appEnvironment);
 
-            AnsiConsole.Render(new Markup("Listing installed plugins:\n"));
+            console.Write(new Markup("Listing installed plugins:\n"));
 
             var table = new Table
             {
@@ -40,7 +39,7 @@ namespace Vellum.Cli.Commands.Plugins
                 table.AddRow(package.Name, package.Version, package.PluginPath.ToString());
             }
 
-            AnsiConsole.Render(table);
+            console.Write(table);
 
             return Task.FromResult(ReturnCodes.Ok);
         }

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/Plugins/PluginUninstallHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/Plugins/PluginUninstallHandler.cs
@@ -17,7 +17,7 @@ namespace Vellum.Cli.Commands.Plugins
     {
         public static async Task<int> ExecuteAsync(
             PluginOptions options,
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/Templates/TemplatePackageInstallerHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/Templates/TemplatePackageInstallerHandler.cs
@@ -18,7 +18,7 @@ namespace Vellum.Cli.Commands.Templates
     {
         public static async Task<int> ExecuteAsync(
             TemplateOptions options,
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {

--- a/Solutions/Vellum.Cli/Vellum/Cli/Commands/Templates/TemplatePackageUninstallerHandler.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Commands/Templates/TemplatePackageUninstallerHandler.cs
@@ -17,7 +17,7 @@ namespace Vellum.Cli.Commands.Templates
     {
         public static async Task<int> ExecuteAsync(
             TemplateOptions options,
-            IConsole console,
+            IVellumConsole console,
             IAppEnvironment appEnvironment,
             InvocationContext context = null)
         {

--- a/Solutions/Vellum.Cli/Vellum/Cli/Infrastructure/AnsiConsoleStreamWriter.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Infrastructure/AnsiConsoleStreamWriter.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="AnsiConsoleStreamWriter.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Vellum.Cli
+{
+    using System.CommandLine.IO;
+    using Spectre.Console;
+
+    internal sealed class AnsiConsoleStreamWriter : IStandardStreamWriter
+    {
+        private readonly IAnsiConsole console;
+
+        public AnsiConsoleStreamWriter(IAnsiConsole console)
+        {
+            this.console = console;
+        }
+
+        public void Write(string value)
+        {
+            this.console.Write(value);
+        }
+    }
+}

--- a/Solutions/Vellum.Cli/Vellum/Cli/Infrastructure/IVellumConsole.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Infrastructure/IVellumConsole.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="IVellumConsole.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Vellum.Cli
+{
+    using System.CommandLine;
+    using Spectre.Console;
+
+    public interface IVellumConsole : IConsole, IAnsiConsole
+    {
+    }
+}

--- a/Solutions/Vellum.Cli/Vellum/Cli/Infrastructure/VellumConsole.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Infrastructure/VellumConsole.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="VellumConsole.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Vellum.Cli
+{
+    using System;
+    using System.CommandLine;
+    using System.CommandLine.IO;
+    using Spectre.Console;
+    using Spectre.Console.Rendering;
+
+    internal sealed class VellumConsole : IVellumConsole
+    {
+        private readonly AnsiConsoleStreamWriter standardOut;
+        private readonly IStandardStreamWriter standardError;
+
+        public VellumConsole()
+        {
+            this.standardOut = new AnsiConsoleStreamWriter(AnsiConsole.Console);
+            this.standardError = StandardStreamWriter.Create(Console.Error);
+        }
+
+        bool IStandardOut.IsOutputRedirected => Console.IsOutputRedirected;
+
+        bool IStandardError.IsErrorRedirected => Console.IsErrorRedirected;
+
+        bool IStandardIn.IsInputRedirected => Console.IsInputRedirected;
+
+        IStandardStreamWriter IStandardOut.Out => this.standardOut;
+
+        IStandardStreamWriter IStandardError.Error => this.standardError;
+
+        public Profile Profile => AnsiConsole.Console.Profile;
+
+        public IAnsiConsoleCursor Cursor => AnsiConsole.Console.Cursor;
+
+        public IAnsiConsoleInput Input => AnsiConsole.Console.Input;
+
+        public IExclusivityMode ExclusivityMode => AnsiConsole.Console.ExclusivityMode;
+
+        public RenderPipeline Pipeline => AnsiConsole.Console.Pipeline;
+
+        public void Clear(bool home)
+        {
+            AnsiConsole.Console.Clear(home);
+        }
+
+        public void Write(IRenderable renderable)
+        {
+            AnsiConsole.Console.Write(renderable);
+        }
+    }
+}

--- a/Solutions/Vellum.Cli/Vellum/Cli/Program.cs
+++ b/Solutions/Vellum.Cli/Vellum/Cli/Program.cs
@@ -5,6 +5,8 @@
 namespace Vellum.Cli
 {
     using System;
+    using System.CommandLine;
+    using System.CommandLine.IO;
     using System.CommandLine.Parsing;
     using System.Text;
     using System.Threading.Tasks;
@@ -22,10 +24,13 @@ namespace Vellum.Cli
 
             ServiceCollection.AddCommonServices();
 
+            var console = new VellumConsole();
+
             return await new CommandLineParser(
+                console,
                 new FileSystemRoamingProfileAppEnvironment(),
                 new CommandPluginHost(),
-                ServiceCollection).Create().InvokeAsync(args).ConfigureAwait(false);
+                ServiceCollection).Create().InvokeAsync(args, console).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
 This commit adds a unifying adapter between the console abstractions provided by Spectre.Console and System.CommandLine.